### PR TITLE
SMTPHandler has to be fully qualified (with a dotted name) to work in the example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -221,7 +221,7 @@ Exception``:
    formatter = generic
 
    [handler_exc_handler]
-   class = SMTPHandler
+   class = logging.handlers.SMTPHandler
    args = (('localhost', 25), 'from@example.com', ['to@example.com'], 'myapp Exception')
    level = ERROR
    formatter = exc_formatter


### PR DESCRIPTION
SMTPHandler has to be fully qualified (with a dotted name) to work, otherwise you get an: ImportError: No module named SMTPHandler
