### PR TITLE
bugfix for params publication

### DIFF
--- a/pyramid_exclog/__init__.py
+++ b/pyramid_exclog/__init__.py
@@ -59,7 +59,7 @@ def exclog_tween_factory(handler, registry):
                 
                 PARAMETERS
                 
-                $(params)s
+                %(params)s
                 
                 
                 """ % dict(url=request.url,


### PR DESCRIPTION
if boolean exclog.extra_info is fixed
params are not published in the returned string
