### PR TITLE
Handle IOError while processing exception

### DIFF
--- a/pyramid_exclog/__init__.py
+++ b/pyramid_exclog/__init__.py
@@ -72,6 +72,8 @@ def _get_message(request):
         params = request.params
     except UnicodeDecodeError:
         params = 'could not decode params'
+    except IOError as ex:
+        params = 'IOError while decoding params: %s' % ex.message
 
     return _MESSAGE_TEMPLATE % dict(
             url=url,


### PR DESCRIPTION
IOError is thrown if the client has gone away. In this case the
exclog gives a cryptic "exception while logging" and the original
error message is lost.