### PR TITLE
pyramid 1.8: avoid pyramid.security.unauthenticated_userid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,4 +10,4 @@ See the documentation at
 http://docs.pylonsproject.org/projects/pyramid_exclog/en/latest/ for more
 information.
 
-This package will only work with Pyramid 1.2a1 and better.
+This package will only work with Pyramid 1.5 and better.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ standard Python :term:`logger`.  This add-on is most useful when used in
 production applications, because the logger can be configured to log to a
 file, to UNIX syslog, to the Windows Event Log, or even to email.
 
-.. warning:: This package will only work with Pyramid 1.2a1 and better.
+.. warning:: This package will only work with Pyramid 1.5 and better.
 
 Installation
 ------------

--- a/pyramid_exclog/__init__.py
+++ b/pyramid_exclog/__init__.py
@@ -6,7 +6,6 @@ from pyramid.settings import aslist
 from pyramid.settings import asbool
 from pyramid.util import DottedNameResolver
 from pyramid.httpexceptions import WSGIHTTPException
-from pyramid.security import unauthenticated_userid
 
 resolver = DottedNameResolver(None)
 
@@ -74,7 +73,7 @@ def _get_message(request):
     will be returned. This seems to be what the logging module expects.
     """
     url = _get_url(request)
-    unauth = unauthenticated_userid(request)
+    unauth = request.unauthenticated_userid
 
     try:
         params = request.params

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except IOError:
     README = CHANGES = ''
 
 install_requires = [
-    'pyramid>=1.2dev',
+    'pyramid>=1.5',
     ]
 
 testing_extras = [


### PR DESCRIPTION
> DeprecationWarning: unauthenticated_userid: As of Pyramid 1.5 the
> "pyramid.security.unauthenticated_userid" API is now deprecated.  It will be
> removed in Pyramid 1.8.  Use the "unauthenticated_userid" attribute of the
> Pyramid request instead.

This change would mean pyramid < 1.5 is no longer supported, but I think 1.6 is the oldest maintained version anyway.