### PR TITLE
Add config option to hide specified cookies in error message

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -105,3 +105,4 @@ Contributors
 - Brian Sutherland, 2013/06/19
 - Marco Falcioni, 2016/09/21
 - Jon Betts, 2021/04/19
+- Lynn Vaughan, 2022/02/22

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -347,6 +347,25 @@ section of your Pyramid's ``.ini`` file.  These are:
 
    If ``exclog.get_message`` is set, ``exclog.extra_info`` will be ignored.
 
+``exclog.hidden_cookies``
+
+   A list of keys of cookies to hide in the error message.  The cookie's value
+   will be replaced with "hidden", so you can still tell whether the cookie was
+   present.
+
+   This works with either ``exclog.extra_info`` or ``exclog.get_message``.  If
+   ``exclog.hidden_cookies`` is set, then any function specified in
+   ``exclog.get_message`` will receive a copy of the request with the cookies
+   already replaced.
+
+   An example:
+
+   .. code-block:: ini
+
+      [app:myapp]
+      exclog.hidden_cookies = auth_tkt
+                              another_cookie
+
 Explicit "Tween" Configuration
 ==============================
 

--- a/pyramid_exclog/tests.py
+++ b/pyramid_exclog/tests.py
@@ -94,6 +94,16 @@ class Test_exclog_tween(unittest.TestCase):
         msg = self.logger.exceptions[0]
         self.assertEqual(msg, 'MESSAGE')
 
+    def test_hidden_cookies(self):
+        self.registry.settings['exclog.extra_info'] = True
+        self.registry.settings['exclog.hidden_cookies'] = ['test_cookie']
+        request = _request_factory('/')
+        request.cookies['test_cookie'] = 'test_cookie_value'
+        self.assertRaises(NotImplementedError, self._callFUT, request=request)
+        msg = self.logger.exceptions[0]
+        self.assertTrue('test_cookie=hidden' in msg, msg)
+        self.assertFalse('test_cookie_value' in msg)
+
     def test_user_info_user(self):
         from pyramid_exclog import _text_type
         self.config.testing_securitypolicy(


### PR DESCRIPTION
This adds an `exclog.hidden_cookies` setting to hide the values of specified cookies in the environ dump when using `extra_info` or `get_message`.  At my workplace, error emails go out to the whole dev team, but we don't want the authtkt cookie to be displayed to everyone.